### PR TITLE
Adapted to latest API changes:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-commons</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/MongoConfiguration.java
+++ b/src/main/java/com/example/MongoConfiguration.java
@@ -32,8 +32,9 @@ public class MongoConfiguration extends AbstractReactiveMongoConfiguration {
 		return Jackson2ObjectMapperBuilder.json().build();
 	}
 
+
 	@Override
-	public MongoClient mongoClient() {
+	public MongoClient reactiveMongoClient() {
 		return MongoClients.create();
 	}
 

--- a/src/main/java/com/example/SpringReactiveDashboardApplication.java
+++ b/src/main/java/com/example/SpringReactiveDashboardApplication.java
@@ -37,7 +37,7 @@ public class SpringReactiveDashboardApplication {
 				);
 
 		return args -> {
-			repository.deleteAll().thenMany(repository.save(people)).blockLast();
+			repository.deleteAll().thenMany(repository.saveAll(people)).blockLast();
 		};
 	}
 

--- a/src/main/java/com/example/dashboard/DefaultDashboardService.java
+++ b/src/main/java/com/example/dashboard/DefaultDashboardService.java
@@ -41,7 +41,7 @@ public class DefaultDashboardService implements DashboardService {
 				.getUsersInRoom(this.properties.getReactor().getGitterRoomId(), 300)
 				.collectList();
 
-		return users.flatMap(gitterUserList -> {
+		return users.flatMapMany(gitterUserList -> {
 			return issues.map(issue -> {
 				String userLogin = issue.getUser().getLogin();
 				Optional<GitterUser> gitterUser = gitterUserList.stream()

--- a/src/main/java/com/example/integration/github/GithubClient.java
+++ b/src/main/java/com/example/integration/github/GithubClient.java
@@ -23,11 +23,13 @@ public class GithubClient {
 
 	public GithubClient(DashboardProperties properties) {
 		this.webClient = WebClient
-				.create("https://api.github.com")
+				.builder()
+				.baseUrl("https://api.github.com")
 				.filter(ExchangeFilterFunctions
 						.basicAuthentication(properties.getGithub().getUsername(),
 								properties.getGithub().getToken()))
-				.filter(userAgent());
+				.filter(userAgent())
+				.build();
 	}
 
 	public Flux<GithubIssue> findOpenIssues(String owner, String repo) {
@@ -35,7 +37,7 @@ public class GithubClient {
 				.get()
 				.uri("/repos/{owner}/{repo}/issues?state=open", owner, repo)
 				.accept(VND_GITHUB_V3)
-				.exchange().flatMap(response -> response.bodyToFlux(GithubIssue.class));
+				.exchange().flatMapMany(response -> response.bodyToFlux(GithubIssue.class));
 	}
 
 

--- a/src/main/java/com/example/integration/gitter/GitterClient.java
+++ b/src/main/java/com/example/integration/gitter/GitterClient.java
@@ -20,8 +20,8 @@ public class GitterClient {
 	private final WebClient webClient;
 
 	public GitterClient(DashboardProperties properties) {
-		this.webClient = WebClient.create()
-				.filter(oAuthToken(properties.getGitter().getToken()));
+		this.webClient = WebClient.builder()
+				.filter(oAuthToken(properties.getGitter().getToken())).build();
 	}
 
 	public Flux<GitterUser> getUsersInRoom(String roomId, int limit) {
@@ -29,7 +29,7 @@ public class GitterClient {
 				.get().uri("https://api.gitter.im/v1/rooms/{roomId}/users?limit={limit}", roomId, limit)
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
-				.flatMap(response -> response.bodyToFlux(GitterUser.class));
+				.flatMapMany(response -> response.bodyToFlux(GitterUser.class));
 	}
 
 	public Mono<GitterUser> findUserInRoom(String userName, String roomId) {
@@ -38,7 +38,7 @@ public class GitterClient {
 				.uri("https://api.gitter.im/v1/rooms/{roomId}/users?q={userName}", roomId, userName)
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
-				.then(response -> response.bodyToMono(GitterUser.class));
+				.flatMap(response -> response.bodyToMono(GitterUser.class));
 	}
 
 	public Flux<GitterMessage> latestChatMessages(String roomId, int limit) {
@@ -47,7 +47,7 @@ public class GitterClient {
 				.uri("https://api.gitter.im/v1/rooms/{roomId}/chatMessages?limit={limit}", roomId, limit)
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
-				.flatMap(response -> response.bodyToFlux(GitterMessage.class));
+				.flatMapMany(response -> response.bodyToFlux(GitterMessage.class));
 	}
 
 	public Flux<GitterMessage> streamChatMessages(String roomId) {
@@ -56,7 +56,7 @@ public class GitterClient {
 				.uri("https://stream.gitter.im/v1/rooms/{roomId}/chatMessages", roomId)
 				.accept(MediaType.TEXT_EVENT_STREAM)
 				.exchange()
-				.flatMap(response -> response.bodyToFlux(GitterMessage.class));
+				.flatMapMany(response -> response.bodyToFlux(GitterMessage.class));
 	}
 
 	private ExchangeFilterFunction oAuthToken(String token) {

--- a/src/main/java/com/example/web/DashboardController.java
+++ b/src/main/java/com/example/web/DashboardController.java
@@ -49,8 +49,8 @@ public class DashboardController {
 	@GetMapping("/reactor/people/{id}")
 	@ResponseBody
 	public Mono<ReactorPerson> findReactorPerson(@PathVariable String id) {
-		return this.repository.findOne(id)
-				.otherwiseIfEmpty(Mono.error(new ReactorPersonNotFoundException(id)));
+		return this.repository.findById(id)
+				.switchIfEmpty(Mono.error(new ReactorPersonNotFoundException(id)));
 	}
 
 	@ExceptionHandler


### PR DESCRIPTION
- flatMapMany() instead of flatMap() to get a Flux
- flatMap() instead of then() to get a Mono
- WebClient.builder().baseUrl(uri) instead of WebClient.create(uri)
- WebClient.Builder.filter() instead of WebClient.filter()
- Repository.saveAll(Provider) instead of Repository.save(Provider)
- Repository.findById(id) instead of Repository.findOne(id)
- reactiveMongoClient() instead of mongoClient()
- Mono.switchIfEmpty(Mono) instead of Mono.otherwiseIfEmpty(Mono)